### PR TITLE
Fix JavaFX dependency by adding it as third party module.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,13 @@
 # Briss 2.0
 
 Briss 2.0 is intended to be a GUI Update for the Briss PDF cropping tool.
+It is based on Briss 0.9 which is located at sourceforge: http://sourceforge.net/projects/briss/
 
-Briss 2.0 is based on Briss 0.9 which is located at sourceforge: http://sourceforge.net/projects/briss/
+### Installation
+
+Currently Briss 2.0 is in alpha therefore some features are still missing (for example the page skip list).
+If you want to give it a try you can download the pre release from https://github.com/mbaeuerle/Briss-2.0/releases.
+You will need Java 11 or newer to run it.
 
 ### Things that are done by now
 - Small refinements on gui which improve the workflow

--- a/build.gradle
+++ b/build.gradle
@@ -1,8 +1,13 @@
-apply plugin: 'java'
-apply plugin: 'application'
+
+plugins {
+    id 'org.openjfx.javafxplugin' version '0.0.8'
+    id 'java'
+    id 'application'
+}
 
 mainClassName = 'at.laborg.briss.Briss'
 applicationDefaultJvmArgs = ["-Xms128m", "-Xmx1024m"]
+def javaFxVersion = '11'
 
 repositories {
     maven { url "http://clojars.org/repo" } // For jpedal
@@ -13,4 +18,19 @@ repositories {
 dependencies {
     compile group: 'com.itextpdf', name: 'itextpdf', version: '5.5.10'
     compile group: 'org.jpedal', name: 'jpedal-lgpl', version: '4.74b27'
+
+    runtimeOnly "org.openjfx:javafx-controls:$javaFxVersion:win"
+    runtimeOnly "org.openjfx:javafx-controls:$javaFxVersion:linux"
+    runtimeOnly "org.openjfx:javafx-controls:$javaFxVersion:mac"
+    runtimeOnly "org.openjfx:javafx-base:$javaFxVersion:win"
+    runtimeOnly "org.openjfx:javafx-base:$javaFxVersion:linux"
+    runtimeOnly "org.openjfx:javafx-base:$javaFxVersion:mac"
+    runtimeOnly "org.openjfx:javafx-swing:$javaFxVersion:win"
+    runtimeOnly "org.openjfx:javafx-swing:$javaFxVersion:linux"
+    runtimeOnly "org.openjfx:javafx-swing:$javaFxVersion:mac"
+}
+
+javafx {
+    version = javaFxVersion
+    modules = [ 'javafx.controls', 'javafx.base', 'javafx.swing' ]
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Thu Aug 02 16:02:28 CST 2018
+#Wed Apr 15 18:44:16 CEST 2020
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.9-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.9-all.zip


### PR DESCRIPTION
JavaFX uses some individual libs for each OS, adding all increases the final zip but should make the executable run on all major platforms.

Minimum Java version is now 11 because this is the minimum JavaFX module version.

Fix #20