### PR TITLE
Remove use of deprecated boxed types constructors

### DIFF
--- a/src/main/java/at/laborg/briss/model/PageCluster.java
+++ b/src/main/java/at/laborg/briss/model/PageCluster.java
@@ -119,7 +119,7 @@ public class PageCluster implements Comparable<PageCluster> {
             float stepWidth = (float) allPages.size() / MAX_MERGE_PAGES;
             float totalStepped = 0;
             for (int i = 0; i < MAX_MERGE_PAGES; i++) {
-                pagesToMerge.add(allPages.get(new Double(Math.floor(totalStepped)).intValue()));
+                pagesToMerge.add(allPages.get(Integer.valueOf((int) Math.floor(totalStepped))));
                 totalStepped += stepWidth;
             }
         }

--- a/src/main/java/at/laborg/briss/model/PageExcludes.java
+++ b/src/main/java/at/laborg/briss/model/PageExcludes.java
@@ -14,6 +14,6 @@ public class PageExcludes {
     }
 
     public final boolean containsPage(final int page) {
-        return excludedPageSet.contains(new Integer(page));
+        return excludedPageSet.contains(Integer.valueOf(page));
     }
 }

--- a/src/main/java/at/laborg/briss/model/SingleCluster.java
+++ b/src/main/java/at/laborg/briss/model/SingleCluster.java
@@ -129,7 +129,7 @@ public class SingleCluster implements Comparable<SingleCluster> {
             float stepWidth = (float) pages.size() / MAX_MERGE_PAGES;
             float totalStepped = 0;
             for (int i = 0; i < MAX_MERGE_PAGES; i++) {
-                pagesToMerge.add(pages.get(new Double(Math.floor(totalStepped)).intValue()));
+                pagesToMerge.add(pages.get(Integer.valueOf((int) Math.floor(totalStepped))));
                 totalStepped += stepWidth;
             }
         }

--- a/src/main/java/at/laborg/briss/utils/FileDrop.java
+++ b/src/main/java/at/laborg/briss/utils/FileDrop.java
@@ -409,7 +409,7 @@ public class FileDrop {
             catch (Exception e) {
                 support = false;
             }   // end catch
-            supportsDnD = new Boolean(support);
+            supportsDnD = Boolean.valueOf(support);
         }   // end if: first time through
         return supportsDnD.booleanValue();
     }   // end supportsDnD


### PR DESCRIPTION
Fixes #32.

Since version 9 the constructors for boxed type are considered to be deprecated and marked for removal. This PR prevents the build from breaking in future JDK versions.
