### PR TITLE
Intuitive selection

### DIFF
--- a/src/main/java/at/laborg/briss/BrissGUI.java
+++ b/src/main/java/at/laborg/briss/BrissGUI.java
@@ -71,6 +71,8 @@ import java.awt.GraphicsEnvironment;
 import java.awt.event.ComponentEvent;
 import java.awt.event.ComponentListener;
 import java.awt.event.KeyEvent;
+import java.awt.event.MouseAdapter;
+import java.awt.event.MouseEvent;
 import java.beans.PropertyChangeEvent;
 import java.beans.PropertyChangeListener;
 import java.io.File;
@@ -197,11 +199,14 @@ public class BrissGUI extends JFrame implements PropertyChangeListener, Componen
 
         setJMenuBar(menuBar);
 
+        MouseAdapter mousePressedAdapter = createMousePressedAdapter();
+
         previewPanel = new JPanel();
         previewPanel.setLayout(new WrapLayout(FlowLayout.LEFT, 4, 4));
         previewPanel.setEnabled(true);
         previewPanel.setBackground(new Color(186, 186, 186));
         previewPanel.addComponentListener(this);
+        previewPanel.addMouseListener(mousePressedAdapter);
 
         progressBar = new JProgressBar(0, 100);
         progressBar.setStringPainted(true);
@@ -245,6 +250,8 @@ public class BrissGUI extends JFrame implements PropertyChangeListener, Componen
         footer.add(showPreview);
         footer.add(startCropping);
         add(footer, BorderLayout.PAGE_END);
+
+        addMouseListener(mousePressedAdapter);
 
         setWindowBounds();
         pack();
@@ -489,6 +496,12 @@ public class BrissGUI extends JFrame implements PropertyChangeListener, Componen
         }
     }
 
+    public void deselectAllRects() {
+        for (MergedPanel mp : mergedPanels) {
+            mp.selectCrops(false);
+        }
+    }
+
     public void setDefinedSizeSelRects() {
         // set size of selected rectangles
         // based on user input
@@ -659,6 +672,15 @@ public class BrissGUI extends JFrame implements PropertyChangeListener, Componen
                 }
             }
         }
+    }
+
+    private MouseAdapter createMousePressedAdapter() {
+        return new MouseAdapter() {
+            @Override
+            public void mousePressed(MouseEvent e) {
+                deselectAllRects();
+            }
+        };
     }
 
     private class ClusterPagesTask extends SwingWorker<Void, Void> {

--- a/src/main/java/at/laborg/briss/gui/MergedPanel.java
+++ b/src/main/java/at/laborg/briss/gui/MergedPanel.java
@@ -580,6 +580,8 @@ public class MergedPanel extends JPanel {
                         briss.moveSelectedRects(x, y);
                     }
                     break;
+                case KeyEvent.VK_ESCAPE:
+                    briss.deselectAllRects();
                 default:
             }
         }

--- a/src/main/java/at/laborg/briss/gui/MergedPanel.java
+++ b/src/main/java/at/laborg/briss/gui/MergedPanel.java
@@ -73,8 +73,7 @@ public class MergedPanel extends JPanel {
     private final static Composite SMOOTH_SELECT = AlphaComposite.getInstance(AlphaComposite.SRC_OVER, .5f);
     private final static Composite XOR_COMPOSITE = AlphaComposite.getInstance(AlphaComposite.SRC_OVER, .8f);
     private final static float[] DASH_PATTERN = {25f, 25f};
-    private final static BasicStroke SELECTED_STROKE = new BasicStroke(SELECT_BORDER_WIDTH, BasicStroke.CAP_SQUARE,
-        BasicStroke.JOIN_BEVEL, 1.0f, DASH_PATTERN, 0f);
+    private final static BasicStroke SELECTED_STROKE = new BasicStroke(SELECT_BORDER_WIDTH);
 
     private final PageCluster cluster;
 
@@ -199,8 +198,7 @@ public class MergedPanel extends JPanel {
         g2.setColor(Color.BLACK);
 
         g2.setStroke(SELECTED_STROKE);
-        g2.drawRect(crop.x + SELECT_BORDER_WIDTH / 2, crop.y + SELECT_BORDER_WIDTH / 2, crop.width - SELECT_BORDER_WIDTH,
-            crop.height - SELECT_BORDER_WIDTH);
+        g2.draw(crop);
 
         // display crop size in milimeters
         int w = Math.round(25.4f * crop.width / 72f);
@@ -477,7 +475,6 @@ public class MergedPanel extends JPanel {
                 crops.add(newCrop);
             }
         }
-        ClipBoard.getInstance().clear();
         updateClusterRatios(crops);
         repaint();
     }
@@ -656,62 +653,38 @@ public class MergedPanel extends JPanel {
                     if (lastDragPoint == null) {
                         lastDragPoint = curPoint;
                     }
-                    if (mE.isShiftDown()) {
-                        briss.moveSelectedRects(curPoint.x - lastDragPoint.x, curPoint.y - lastDragPoint.y);
-                    } else {
-                        curCrop.translate(curPoint.x - lastDragPoint.x, curPoint.y - lastDragPoint.y);
-                    }
+                    briss.moveSelectedRects(curPoint.x - lastDragPoint.x, curPoint.y - lastDragPoint.y);
                     lastDragPoint = curPoint;
                     break;
                 case RESIZING_HOTCORNER_LR:
                     if (lastDragPoint == null) {
                         lastDragPoint = curPoint;
                     }
-                    if (mE.isShiftDown()) {
-                        briss.resizeSelRects(curPoint.x - lastDragPoint.x, curPoint.y - lastDragPoint.y);
-                    } else {
-                        curPoint.translate(relativeHotCornerGrabDistance.x, relativeHotCornerGrabDistance.y);
-                        curCrop.setNewHotCornerLR(curPoint);
-                    }
+                    briss.resizeSelRects(curPoint.x - lastDragPoint.x, curPoint.y - lastDragPoint.y);
                     lastDragPoint = curPoint;
                     break;
                 case RESIZING_HOTCORNER_UL:
                     if (lastDragPoint == null) {
                         lastDragPoint = curPoint;
                     }
-                    if (mE.isShiftDown()) {
-                        briss.resizeSelRects(lastDragPoint.x - curPoint.x, lastDragPoint.y - curPoint.y);
-                        briss.moveSelectedRects(curPoint.x - lastDragPoint.x, curPoint.y - lastDragPoint.y);
-                    } else {
-                        curPoint.translate(relativeHotCornerGrabDistance.x, relativeHotCornerGrabDistance.y);
-                        curCrop.setNewHotCornerUL(curPoint);
-                    }
+                    briss.resizeSelRects(lastDragPoint.x - curPoint.x, lastDragPoint.y - curPoint.y);
+                    briss.moveSelectedRects(curPoint.x - lastDragPoint.x, curPoint.y - lastDragPoint.y);
                     lastDragPoint = curPoint;
                     break;
                 case RESIZING_HOTCORNER_UR:
                     if (lastDragPoint == null) {
                         lastDragPoint = curPoint;
                     }
-                    if (mE.isShiftDown()) {
-                        briss.resizeSelRects(curPoint.x - lastDragPoint.x, lastDragPoint.y - curPoint.y);
-                        briss.moveSelectedRects(0, curPoint.y - lastDragPoint.y);
-                    } else {
-                        curPoint.translate(relativeHotCornerGrabDistance.x, relativeHotCornerGrabDistance.y);
-                        curCrop.setNewHotCornerUR(curPoint);
-                    }
+                    briss.resizeSelRects(curPoint.x - lastDragPoint.x, lastDragPoint.y - curPoint.y);
+                    briss.moveSelectedRects(0, curPoint.y - lastDragPoint.y);
                     lastDragPoint = curPoint;
                     break;
                 case RESIZING_HOTCORNER_LL:
                     if (lastDragPoint == null) {
                         lastDragPoint = curPoint;
                     }
-                    if (mE.isShiftDown()) {
-                        briss.resizeSelRects(lastDragPoint.x - curPoint.x, curPoint.y - lastDragPoint.y);
-                        briss.moveSelectedRects(curPoint.x - lastDragPoint.x, 0);
-                    } else {
-                        curPoint.translate(relativeHotCornerGrabDistance.x, relativeHotCornerGrabDistance.y);
-                        curCrop.setNewHotCornerLL(curPoint);
-                    }
+                    briss.resizeSelRects(lastDragPoint.x - curPoint.x, curPoint.y - lastDragPoint.y);
+                    briss.moveSelectedRects(curPoint.x - lastDragPoint.x, 0);
                     lastDragPoint = curPoint;
                     break;
                 case RESIZING_LEFT_EDGE:
@@ -719,12 +692,8 @@ public class MergedPanel extends JPanel {
                         lastDragPoint = curPoint;
                     }
 
-                    if (mE.isShiftDown()) {
-                        briss.resizeSelRects(lastDragPoint.x - curPoint.x, 0);
-                        briss.moveSelectedRects(curPoint.x - lastDragPoint.x, 0);
-                    } else {
-                        curCrop.moveLeftEdge(curPoint);
-                    }
+                    briss.resizeSelRects(lastDragPoint.x - curPoint.x, 0);
+                    briss.moveSelectedRects(curPoint.x - lastDragPoint.x, 0);
                     lastDragPoint = curPoint;
                     break;
 
@@ -733,11 +702,7 @@ public class MergedPanel extends JPanel {
                         lastDragPoint = curPoint;
                     }
 
-                    if (mE.isShiftDown()) {
-                        briss.resizeSelRects(curPoint.x - lastDragPoint.x, 0);
-                    } else {
-                        curCrop.moveRightEdge(curPoint);
-                    }
+                    briss.resizeSelRects(curPoint.x - lastDragPoint.x, 0);
                     lastDragPoint = curPoint;
                     break;
 
@@ -746,12 +711,8 @@ public class MergedPanel extends JPanel {
                         lastDragPoint = curPoint;
                     }
 
-                    if (mE.isShiftDown()) {
-                        briss.resizeSelRects(0, lastDragPoint.y - curPoint.y);
-                        briss.moveSelectedRects(0, curPoint.y - lastDragPoint.y);
-                    } else {
-                        curCrop.moveUpperEdge(curPoint);
-                    }
+                    briss.resizeSelRects(0, lastDragPoint.y - curPoint.y);
+                    briss.moveSelectedRects(0, curPoint.y - lastDragPoint.y);
                     lastDragPoint = curPoint;
                     break;
 
@@ -760,15 +721,11 @@ public class MergedPanel extends JPanel {
                         lastDragPoint = curPoint;
                     }
 
-                    if (mE.isShiftDown()) {
-                        briss.resizeSelRects(0, curPoint.y - lastDragPoint.y);
-                    } else {
-                        curCrop.moveLowerEdge(curPoint);
-                    }
+                    briss.resizeSelRects(0, curPoint.y - lastDragPoint.y);
                     lastDragPoint = curPoint;
                     break;
-            default:
-                break;
+                default:
+                    break;
             }
             repaint();
         }
@@ -779,11 +736,24 @@ public class MergedPanel extends JPanel {
             Point p = mE.getPoint();
             if (mE.isPopupTrigger()) {
                 showPopUpMenu(mE);
+                return;
             }
 
-            if (mE.isControlDown()) {
+            if (mE.isShiftDown()) {
                 changeSelectRectangle(p);
                 return;
+            } else {
+                for (DrawableCropRect crop : crops) {
+                    if (crop.contains(p)) {
+                        if (!crop.isSelected()) {
+                            briss.deselectAllRects();
+                            crop.setSelected(true);
+                        }
+                        break;
+                    }
+                }
+
+                repaint();
             }
 
             if (SwingUtilities.isLeftMouseButton(mE)) {
@@ -827,11 +797,13 @@ public class MergedPanel extends JPanel {
                 }
 
                 setCursor(Cursor.getPredefinedCursor(Cursor.DEFAULT_CURSOR));
+                briss.deselectAllRects();
 
                 // otherwise draw a new one
                 actionState = ActionState.DRAWING_NEW_CROP;
                 if (curCrop == null) {
                     curCrop = new DrawableCropRect();
+                    curCrop.setSelected(true);
                     crops.add(curCrop);
                     cropStartPoint = p;
                 }


### PR DESCRIPTION
This PR will introduce a new way of how crop rects are selected.
Prevously:
* Resizing a rect was possible without being selected
* Selection/deselection was done with `ctrl` + click
* Moving and scaling multiple rects synchronous was only possible while holding shift

With this PR:
* Clicking on a rect will select it
* `Shift` + click adds a rect to the selection (or removes it if it was already part of it)
* Deselection of all rects is done by either
  * clicking anywhere else but the selected rects
  * pressing ESC
  * A new selection is started by clicking on a rect which was not selected before (without shift)
* Moving and scaling multiple rects synchronously is now done without a modifier

I think that is a more natural way for selecting objects, less cumbersome and is also more familiar from other tools like Powerpoint, Keynote, etc.