### PR TITLE
Improve resize handle management

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Changed
 
+* Redesign of the resize handles to make them more modern
 * Allow for crop rectangle copy and paste on same panel
 * [Issue-41](https://github.com/mbaeuerle/Briss-2.0/issues/41) Reverse crop rectangle selection order. Newest rectangle under cursor is selected.
 * Update to Gradle 7.4

--- a/src/main/java/at/laborg/briss/gui/DrawableCropRect.java
+++ b/src/main/java/at/laborg/briss/gui/DrawableCropRect.java
@@ -3,6 +3,8 @@
  */
 package at.laborg.briss.gui;
 
+import java.awt.Color;
+import java.awt.Graphics2D;
 import java.awt.Point;
 import java.awt.Rectangle;
 
@@ -12,9 +14,14 @@ public class DrawableCropRect extends Rectangle {
 
 	private static final long serialVersionUID = -8836495805271750636L;
 
-    static final int CORNER_DIMENSION = 20;
+    static final int CORNER_DIMENSION = 15;
 
     private boolean selected = false;
+
+    private Rectangle cornerUpperLeft;
+    private Rectangle cornerUpperRight;
+    private Rectangle cornerLowerLeft;
+    private Rectangle cornerLowerRight;
 
     /**
      * Copy constructor.
@@ -27,6 +34,9 @@ public class DrawableCropRect extends Rectangle {
         this.y = crop.y;
         this.height = crop.height;
         this.width = crop.width;
+        this.selected = false;
+        setupCorners();
+        setCornerLocations(x, y);
     }
 
     public DrawableCropRect(int x, int y, int width, int height) {
@@ -35,6 +45,40 @@ public class DrawableCropRect extends Rectangle {
         this.y = y;
         this.height = height;
         this.width = width;
+        setupCorners();
+        setCornerLocations(x, y);
+    }
+
+    private void setupCorners() {
+        cornerUpperLeft = new Rectangle(CORNER_DIMENSION, CORNER_DIMENSION);
+        cornerUpperRight = new Rectangle(CORNER_DIMENSION, CORNER_DIMENSION);
+        cornerLowerLeft = new Rectangle(CORNER_DIMENSION, CORNER_DIMENSION);
+        cornerLowerRight = new Rectangle(CORNER_DIMENSION, CORNER_DIMENSION);
+    }
+
+    private void setCornerLocations(int x, int y) {
+        int halfCornerDimension = CORNER_DIMENSION / 2;
+        cornerUpperLeft.setLocation(x - halfCornerDimension, y - halfCornerDimension);
+        cornerUpperRight.setLocation(x + width - halfCornerDimension, y - halfCornerDimension);
+        cornerLowerLeft.setLocation(x - halfCornerDimension, y + height - halfCornerDimension);
+        cornerLowerRight.setLocation(x + width - halfCornerDimension, y + height - halfCornerDimension);
+    }
+
+    public void draw(Graphics2D g2) {
+
+        if (isSelected()) {
+            g2.setPaintMode();
+            g2.setColor(Color.WHITE);
+            g2.fill(cornerUpperLeft);
+            g2.fill(cornerUpperRight);
+            g2.fill(cornerLowerLeft);
+            g2.fill(cornerLowerRight);
+            g2.setColor(Color.BLACK);
+            g2.draw(cornerUpperLeft);
+            g2.draw(cornerUpperRight);
+            g2.draw(cornerLowerLeft);
+            g2.draw(cornerLowerRight);
+        }
     }
 
     public final boolean isSelected() {
@@ -46,36 +90,57 @@ public class DrawableCropRect extends Rectangle {
     }
 
     public final boolean containsInHotCornerUL(final Point p) {
-        return ((p.x > getX() && p.x <= getX() + CORNER_DIMENSION) && (p.y > getY() && p.y <= getY() + CORNER_DIMENSION));
+        return isSelected() && cornerUpperLeft.contains(p);
     }
 
     public final boolean containsInHotCornerLR(final Point p) {
-        return ((p.x < getMaxX() && p.x > getMaxX() - CORNER_DIMENSION) && (p.y < getMaxY() && p.y > getMaxY()
-            - CORNER_DIMENSION));
+        return isSelected() && cornerLowerRight.contains(p);
     }
 
     public final boolean containsInHotCornerUR(final Point p) {
-        return ((p.x < getMaxX() && p.x > getMaxX() - CORNER_DIMENSION) && (p.y > getY() && p.y <= getY() + CORNER_DIMENSION));
+        return isSelected() && cornerUpperRight.contains(p);
     }
 
     public final boolean containsInHotCornerLL(final Point p) {
-        return ((p.x > getX() && p.x <= getX() + CORNER_DIMENSION) && (p.y < getMaxY() && p.y > getMaxY()
-                - CORNER_DIMENSION));
+        return isSelected() && cornerLowerLeft.contains(p);
     }
 
 	public boolean isOverRightEdge(Point p) {
-		return Math.abs(p.x - getMaxX()) < EDGE_THRESHOLD && p.y > y && p.y - y < height;
+		return isSelected() && Math.abs(p.x - getMaxX()) < EDGE_THRESHOLD && p.y > y && p.y - y < height;
 	}
 
 	public boolean isOverLeftEdge(Point p) {
-		return Math.abs(p.x - x) < EDGE_THRESHOLD && p.y > y && p.y - y < height;
+		return isSelected() && Math.abs(p.x - x) < EDGE_THRESHOLD && p.y > y && p.y - y < height;
 	}
 
 	public boolean isOverUpperEdge(Point p) {
-		return Math.abs(p.y - y) < EDGE_THRESHOLD && p.x > x && p.x - x < width;
+		return isSelected() && Math.abs(p.y - y) < EDGE_THRESHOLD && p.x > x && p.x - x < width;
 	}
 
 	public boolean isOverLowerEdge(Point p) {
-		return Math.abs(p.y - getMaxY()) < EDGE_THRESHOLD && p.x > x && p.x - x < width;
+		return isSelected() && Math.abs(p.y - getMaxY()) < EDGE_THRESHOLD && p.x > x && p.x - x < width;
 	}
+
+    @Override
+    public void setLocation(int x, int y) {
+        super.setLocation(x, y);
+        setCornerLocations(x, y);
+    }
+
+    @Override
+    public void setBounds(int x, int y, int width, int height) {
+        super.setBounds(x, y, width, height);
+        setCornerLocations(x, y);
+    }
+
+    @Override
+    public void setSize(int width, int height) {
+        super.setSize(width, height);
+        setCornerLocations(this.x, this.y);
+    }
+
+    @Override
+    public boolean contains(Point p) {
+        return super.contains(p) || isSelected() && (isOverRightEdge(p) || isOverLeftEdge(p) || isOverUpperEdge(p) || isOverLowerEdge(p) || cornerUpperLeft.contains(p) || cornerUpperRight.contains(p) || cornerLowerLeft.contains(p) || cornerLowerRight.contains(p));
+    }
 }

--- a/src/main/java/at/laborg/briss/gui/MergedPanel.java
+++ b/src/main/java/at/laborg/briss/gui/MergedPanel.java
@@ -152,11 +152,6 @@ public class MergedPanel extends JPanel {
 
     @Override
     public void paint(Graphics g) {
-        update(g);
-    }
-
-    @Override
-    public void update(Graphics g) {
         if (!isEnabled())
             return;
 
@@ -168,10 +163,10 @@ public class MergedPanel extends JPanel {
         int cropCnt = 0;
 
         for (DrawableCropRect crop : crops) {
-            drawNormalCropRectangle(g2, cropCnt, crop);
             if (crop.isSelected()) {
                 drawSelectionOverlay(g2, crop);
             }
+            drawNormalCropRectangle(g2, cropCnt, crop);
 
             cropCnt++;
         }
@@ -192,12 +187,8 @@ public class MergedPanel extends JPanel {
         g2.setFont(scaleFont(String.valueOf(cropCnt + 1), crop));
         g2.drawString(String.valueOf(cropCnt + 1), crop.x, crop.y + crop.height);
 
-        int cD = DrawableCropRect.CORNER_DIMENSION;
         if (hasEnoughRoomForResizeHandle(crop)) {
-            g2.fillRect(crop.x, crop.y, cD, cD);
-            g2.fillRect(crop.x + crop.width - cD, crop.y, cD, cD);
-            g2.fillRect(crop.x, crop.y + crop.height - cD, cD, cD);
-            g2.fillRect(crop.x + crop.width - cD, crop.y + crop.height - cD, cD, cD);
+            crop.draw(g2);
         }
     }
 
@@ -685,10 +676,11 @@ public class MergedPanel extends JPanel {
                     if (cropStartPoint == null) {
                         cropStartPoint = curPoint;
                     }
-                    curCrop.x = Math.min(curPoint.x, cropStartPoint.x);
-                    curCrop.width = Math.abs(curPoint.x - cropStartPoint.x);
-                    curCrop.y = Math.min(curPoint.y, cropStartPoint.y);
-                    curCrop.height = Math.abs(curPoint.y - cropStartPoint.y);
+                    int x = Math.min(curPoint.x, cropStartPoint.x);
+                    int y = Math.min(curPoint.y, cropStartPoint.y);
+                    int width = Math.abs(curPoint.x - cropStartPoint.x);
+                    int height = Math.abs(curPoint.y - cropStartPoint.y);
+                    curCrop.setBounds(x, y, width, height);
                     break;
 
                 case MOVE_CROP:


### PR DESCRIPTION
* Resize handles are redesigned and look more like in other applications
* Resize handles only appear on selected rectangles
* Visual handle is now independent of draggable handle area allowing for resizing also outside of drawn handle rectangle

Currently:
<img width="130" alt="image" src="https://user-images.githubusercontent.com/1345394/160910440-3d3364f8-d8f1-43a0-b13c-2604b571e5a0.png">
With this PR:
<img width="84" alt="image" src="https://user-images.githubusercontent.com/1345394/160910354-8351260e-3c8c-47c5-9320-1c4ee4536716.png">