### PR TITLE
Fix #52 Remove PDF size restriction to allow crops of bigger files

### DIFF
--- a/src/main/java/at/laborg/briss/ClusterManager.java
+++ b/src/main/java/at/laborg/briss/ClusterManager.java
@@ -93,15 +93,10 @@ public class ClusterManager {
 
             for (SingleCluster cluster : clusterJob.getClusterCollection().getAsList()) {
                 for (Integer pageNumber : cluster.getPagesToMerge()) {
-                    // TODO jpedal isn't able to render big images
-                    // correctly, so let's check if the image is big an
-                    // throw it away
                     try {
-                        if (cluster.getImageData().isRenderable()) {
-                            BufferedImage renderedPage = pdfDecoder.getPageAsImage(pageNumber);
-                            cluster.getImageData().addImageToPreview(renderedPage);
-                            workerUnitCounter++;
-                        }
+                        BufferedImage renderedPage = pdfDecoder.getPageAsImage(pageNumber);
+                        cluster.getImageData().addImageToPreview(renderedPage);
+                        workerUnitCounter++;
                     } catch (PdfException e) {
                         // TODO Auto-generated catch block
                         e.printStackTrace();

--- a/src/main/java/at/laborg/briss/gui/MergedPanel.java
+++ b/src/main/java/at/laborg/briss/gui/MergedPanel.java
@@ -101,11 +101,11 @@ public class MergedPanel extends JPanel {
         cluster.addRatios(autoRatios);
         setPreferredSize(new Dimension(img.getWidth(), img.getHeight()));
         setSize(new Dimension(img.getWidth(), img.getHeight()));
-        if (cluster.getImageData().isRenderable()) {
-            MergedPanelMouseAdapter mouseAdapter = new MergedPanelMouseAdapter();
-            addMouseMotionListener(mouseAdapter);
-            addMouseListener(mouseAdapter);
-        }
+
+        MergedPanelMouseAdapter mouseAdapter = new MergedPanelMouseAdapter();
+        addMouseMotionListener(mouseAdapter);
+        addMouseListener(mouseAdapter);
+
         addRatiosAsCrops(cluster.getRatiosList());
         setToolTipText(createInfoString(cluster));
         addKeyListener(new MergedPanelKeyAdapter());

--- a/src/main/java/at/laborg/briss/model/ClusterImageData.java
+++ b/src/main/java/at/laborg/briss/model/ClusterImageData.java
@@ -10,10 +10,7 @@ import java.awt.image.WritableRaster;
 public class ClusterImageData {
 
     private static final int MAX_PAGE_HEIGHT = 900;
-    private static final int MAX_IMAGE_RENDER_SIZE = 2000 * 2000;
     public static final double IDENTICAL_PIXELS_THRESHOLD = 0.8;
-
-    private final boolean renderable;
     private BufferedImage outputImage = null;
     private int outputImageHeight = -1;
     private int outputImageWidth = -1;
@@ -21,18 +18,11 @@ public class ClusterImageData {
     private int imageCnt = 0;
     private final int totalImages;
 
-    public ClusterImageData(final int pageWidth, final int pageHeight, final int nrOfImages) {
-        this.renderable = pageWidth * pageHeight < MAX_IMAGE_RENDER_SIZE;
+    public ClusterImageData(final int nrOfImages) {
         totalImages = nrOfImages;
     }
 
-    public final boolean isRenderable() {
-        return renderable;
-    }
-
     public final void addImageToPreview(final BufferedImage imageToAdd) {
-        if (!renderable)
-            return;
         if (outputImageHeight == -1) {
             initializeOutputImage(imageToAdd);
         }
@@ -40,7 +30,7 @@ public class ClusterImageData {
     }
 
     private void initializeOutputImage(final BufferedImage imageToAdd) {
-        outputImageHeight = imageToAdd.getHeight() > MAX_PAGE_HEIGHT ? MAX_PAGE_HEIGHT : imageToAdd.getHeight();
+        outputImageHeight = Math.min(imageToAdd.getHeight(), MAX_PAGE_HEIGHT);
         float scaleFactor = (float) outputImageHeight / imageToAdd.getHeight();
         outputImageWidth = (int) (imageToAdd.getWidth() * scaleFactor);
         inputImages = new BufferedImage[totalImages];
@@ -52,9 +42,6 @@ public class ClusterImageData {
     }
 
     public final BufferedImage getPreviewImage() {
-
-        if (!renderable)
-            return getUnrenderableImage();
         if (outputImage == null) {
             outputImage = renderOutputImage();
             inputImages = null;
@@ -98,29 +85,6 @@ public class ClusterImageData {
         g.dispose();
 
         return bdest;
-    }
-
-    private static BufferedImage getUnrenderableImage() {
-        int width = 200;
-        int height = 200;
-
-        // Create buffered image that does not support transparency
-        BufferedImage bimage = new BufferedImage(width, height, BufferedImage.TYPE_INT_RGB);
-
-        Graphics2D g2d = bimage.createGraphics();
-
-        // Draw on the image
-        g2d.setColor(Color.WHITE);
-        g2d.drawRect(5, 5, 190, 190);
-
-        Font font = new Font("Sansserif", Font.BOLD | Font.PLAIN, 22);
-        g2d.setFont(font);
-
-        g2d.setColor(Color.WHITE);
-        g2d.drawString("Image to Big!", 10, 110);
-
-        g2d.dispose();
-        return bimage;
     }
 
     private int[][] calculateOverlayOfImages(final BufferedImage[] images, final int imageCnt) {

--- a/src/main/java/at/laborg/briss/model/PageCluster.java
+++ b/src/main/java/at/laborg/briss/model/PageCluster.java
@@ -52,7 +52,7 @@ public class PageCluster implements Comparable<PageCluster> {
 
     public final ClusterImageData getImageData() {
         if (imageData == null) {
-            imageData = new ClusterImageData(pageWidth, pageHeight, pagesToMerge.size());
+            imageData = new ClusterImageData(pagesToMerge.size());
         }
         return imageData;
     }

--- a/src/main/java/at/laborg/briss/model/SingleCluster.java
+++ b/src/main/java/at/laborg/briss/model/SingleCluster.java
@@ -48,7 +48,7 @@ public class SingleCluster implements Comparable<SingleCluster> {
 
     public ClusterImageData getImageData() {
         if (imageData == null)
-            imageData = new ClusterImageData(pageWidth, pageHeight, pagesToMerge.size());
+            imageData = new ClusterImageData(pagesToMerge.size());
         return imageData;
     }
 

--- a/src/main/java/at/laborg/briss/utils/ClusterRenderWorker.java
+++ b/src/main/java/at/laborg/briss/utils/ClusterRenderWorker.java
@@ -37,15 +37,10 @@ public class ClusterRenderWorker extends Thread {
 
         for (PageCluster cluster : clusters.getClusterList()) {
             for (Integer pageNumber : cluster.getPagesToMerge()) {
-                // TODO jpedal isn't able to render big images
-                // correctly, so let's check if the image is big an
-                // throw it away
                 try {
-                    if (cluster.getImageData().isRenderable()) {
-                        BufferedImage renderedPage = pdfDecoder.getPageAsImage(pageNumber);
-                        cluster.getImageData().addImageToPreview(renderedPage);
-                        workerUnitCounter++;
-                    }
+                    BufferedImage renderedPage = pdfDecoder.getPageAsImage(pageNumber);
+                    cluster.getImageData().addImageToPreview(renderedPage);
+                    workerUnitCounter++;
                 } catch (PdfException e) {
                     // TODO Auto-generated catch block
                     e.printStackTrace();


### PR DESCRIPTION
This could lead to unexpected results when using very big files. Din A0 seems to be handled fine though.