### PR TITLE
Support Wayland: Update javafx plugin to 0.0.13 in build.gradle.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id 'org.openjfx.javafxplugin' version '0.0.8'
+    id 'org.openjfx.javafxplugin' version '0.0.13'
     id 'java'
     id 'application'
 }


### PR DESCRIPTION
Added support for Wayland by updating JavaFX to 0.0.13. Tested on Pop_OS 20.04 running Wayland.