### PR TITLE
fix a build error, see below

### DIFF
--- a/src/main/java/at/laborg/briss/BrissSwingGUI.java
+++ b/src/main/java/at/laborg/briss/BrissSwingGUI.java
@@ -340,7 +340,7 @@ public class BrissSwingGUI implements BrissGUIApp {
 		initFileChooser();
 		fileChooser.setTitle("Open PDF File");
 		fileChooser.setMode(FileDialog.LOAD);
-        fileChooser.setFile("*.pdf");
+		fileChooser.setFile("*.pdf");
 		fileChooser.setVisible(true);
 		String filename = fileChooser.getFile();
 		String directory = fileChooser.getDirectory();


### PR DESCRIPTION
there seem to be a formatting error preventing compile using Java 19, fixed here.
````
weiwu@weiwu-21BXCTO1WW:~/IdeaProjects/Briss-2.0$ ./gradlew build

> Task :compileJava
Note: /home/weiwu/IdeaProjects/Briss-2.0/src/main/java/at/laborg/briss/gui/MergedPanel.java uses or overrides a deprecated API. Note: Recompile with -Xlint:deprecation for details. Note: /home/weiwu/IdeaProjects/Briss-2.0/src/main/java/at/laborg/briss/utils/FileDrop.java uses unchecked or unsafe operations. Note: Recompile with -Xlint:unchecked for details.

> Task :spotlessJavaCheck FAILED

FAILURE: Build failed with an exception.

* What went wrong: Execution failed for task ':spotlessJavaCheck'.
> The following files had format violations:
      src/main/java/at/laborg/briss/BrissSwingGUI.java
          @@ -340,7 +340,7 @@
           \t\tinitFileChooser();
           \t\tfileChooser.setTitle("Open·PDF·File");
           \t\tfileChooser.setMode(FileDialog.LOAD);
          -········fileChooser.setFile("*.pdf");
          +\t\tfileChooser.setFile("*.pdf");
           \t\tfileChooser.setVisible(true);
           \t\tString·filename·=·fileChooser.getFile();
           \t\tString·directory·=·fileChooser.getDirectory();
  Run './gradlew :spotlessApply' to fix these violations.

* Try:
> Run with --stacktrace option to get the stack trace.
> Run with --info or --debug option to get more log output.
> Run with --scan to get full insights.

* Get more help at https://help.gradle.org

BUILD FAILED in 23s
13 actionable tasks: 13 executed
```

Now it compiles:
```
weiwu@weiwu-21BXCTO1WW:~/IdeaProjects/Briss-2.0$ ./gradlew :spotlessApply

BUILD SUCCESSFUL in 646ms
3 actionable tasks: 1 executed, 2 up-to-date
````