### PR TITLE
Display crop ratio in overlay

### DIFF
--- a/src/main/java/at/laborg/briss/gui/DrawableCropRect.java
+++ b/src/main/java/at/laborg/briss/gui/DrawableCropRect.java
@@ -12,6 +12,7 @@ import java.awt.FontMetrics;
 import java.awt.Graphics2D;
 import java.awt.Point;
 import java.awt.Rectangle;
+import java.util.Locale;
 
 public class DrawableCropRect extends Rectangle {
 
@@ -139,6 +140,15 @@ public class DrawableCropRect extends Rectangle {
 		int w = Math.round(INCH_IN_MILLIMETERS * this.width / INCH_IN_USER_UNIT);
 		int h = Math.round(INCH_IN_MILLIMETERS * this.height / INCH_IN_USER_UNIT);
 		String size = w + "x" + h;
+		// Add 1:x.xx aspect ratio
+		if (h > 0 && w > 0) {
+			float ratio = (float) w / (float) h;
+			if (ratio < 1) {
+				ratio = 1 / ratio;
+			}
+			// Locale.ROOT forces a dot as separator
+			size +=	String.format(Locale.ROOT, " 1:%.2f", ratio);
+		}
 		g2.setFont(scaleFont(size, fontMetrics));
 		g2.setColor(Color.YELLOW);
 		g2.setComposite(SMOOTH_SELECT);

--- a/src/main/java/at/laborg/briss/gui/DrawableCropRect.java
+++ b/src/main/java/at/laborg/briss/gui/DrawableCropRect.java
@@ -147,7 +147,7 @@ public class DrawableCropRect extends Rectangle {
 				ratio = 1 / ratio;
 			}
 			// Locale.ROOT forces a dot as separator
-			size +=	String.format(Locale.ROOT, " 1:%.2f", ratio);
+			size += String.format(Locale.ROOT, " 1:%.2f", ratio);
 		}
 		g2.setFont(scaleFont(size, fontMetrics));
 		g2.setColor(Color.YELLOW);


### PR DESCRIPTION
Add crop ratio to the crop overlay, as suggested in https://github.com/mbaeuerle/Briss-2.0/issues/4#issuecomment-2544819750

<img width="522" alt="Screenshot 2024-12-16 at 16 58 38" src="https://github.com/user-attachments/assets/d433199d-a610-478d-9263-6bc8db9d71e6" />
<img width="550" alt="Screenshot 2024-12-16 at 16 58 52" src="https://github.com/user-attachments/assets/b1633b35-d2a3-4de8-92b1-b37245afa226" />
